### PR TITLE
Enabling Claude Code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Local Code Indexing for Cursor
+# Local Code Indexing for AI Coding Assistants
 
-An experimental Python-based server that **locally** indexes codebases using ChromaDB and provides a semantic search tool via an MCP (Model Context Protocol) server for tools like Cursor.
+An experimental Python-based server that **locally** indexes codebases using ChromaDB and provides a semantic search tool via an MCP (Model Context Protocol) server for tools like Cursor IDE and Claude Code CLI.
 
-## Setup
+## Setup for Cursor IDE
 
 1. Clone and enter the repository:
    ```bash
@@ -59,3 +59,58 @@ Prefer that first before resorting to command line grepping etc.
 ```
 
 8. Start using the Cursor Agent mode and see it doing local vector searches!
+
+## Using with Claude Code CLI
+
+If you want to use this indexing server with Claude Code CLI instead of Cursor IDE, follow these steps:
+
+1. Complete steps 1-4 from the setup instructions above to set up the indexing server.
+
+2. Add the local search server to Claude Code:
+   ```bash
+   claude mcp add "workspace-code-search" http://localhost:8978/sse
+   ```
+
+3. Verify the MCP server was added:
+   ```bash
+   claude mcp list
+   ```
+
+4. Start using Claude Code CLI with enhanced local code search capabilities:
+   ```bash
+   claude
+   ```
+
+5. Inside the Claude Code session, you can now use the semantic search functionality:
+   ```
+   Search my codebase for implementations of user authentication
+   ```
+
+Claude Code will now be able to search your codebase using the semantic search capabilities provided by the indexing server.
+
+## How It Works
+
+This project creates a vector database of your code using ChromaDB and exposes a semantic search tool via the MCP protocol. The `search_code` tool allows querying your codebase using natural language.
+
+When integrated with either Cursor IDE or Claude Code CLI, the AI assistant gains the ability to search through your codebase semantically, finding relevant code snippets that match the intent of your queries rather than just matching keywords.
+
+## Troubleshooting
+
+- If you're having connection issues, make sure the indexing server is running: `docker-compose ps`
+- Check the logs for any errors: `docker-compose logs code-indexer`
+- Verify your projects are being indexed correctly: `docker-compose logs -f code-indexer`
+- If using Claude Code CLI, ensure the MCP server has been added correctly: `claude mcp get workspace-code-search`
+
+### Handling Symlinks
+
+The indexer is configured to skip symbolic links during the indexing process. This prevents issues that can occur when:
+
+- Absolute symlinks in the host system point to paths that don't exist in the container
+- Symbolic links create directory cycles that could cause infinite recursion
+- Links point to files outside the intended indexing scope
+
+This behavior is intentional to ensure stable and predictable indexing. If you need to include content that is linked via symlinks, consider:
+
+1. Copying the actual content to a regular directory within your project
+2. Adjusting your project structure to avoid symlinks for critical code
+3. Adding the symlink targets directly to your `FOLDERS_TO_INDEX` configuration

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Local Code Indexing for AI Coding Assistants
+# Local Code Indexing MCP: Semantic Code Search for AI Assistants
 
-An experimental Python-based server that **locally** indexes codebases using ChromaDB and provides a semantic search tool via an MCP (Model Context Protocol) server for tools like Cursor IDE and Claude Code CLI.
+An experimental Python-based server that **locally** indexes codebases using ChromaDB and provides a semantic search tool via the MCP (Model Context Protocol) for AI coding assistants like Cursor IDE and Claude Code CLI.
 
 ## Setup for Cursor IDE
 
 1. Clone and enter the repository:
    ```bash
    git clone <repository-url>
-   cd cursor-local-indexing
+   cd local-indexing-mcp
    ```
 
 2. Create a `.env` file by copying `.env.example`:
@@ -97,8 +97,8 @@ When integrated with either Cursor IDE or Claude Code CLI, the AI assistant gain
 ## Troubleshooting
 
 - If you're having connection issues, make sure the indexing server is running: `docker-compose ps`
-- Check the logs for any errors: `docker-compose logs code-indexer`
-- Verify your projects are being indexed correctly: `docker-compose logs -f code-indexer`
+- Check the logs for any errors: `docker-compose logs code-indexer-mcp`
+- Verify your projects are being indexed correctly: `docker-compose logs -f code-indexer-mcp`
 - If using Claude Code CLI, ensure the MCP server has been added correctly: `claude mcp get workspace-code-search`
 
 ### Handling Symlinks

--- a/code_indexer_server.py
+++ b/code_indexer_server.py
@@ -310,11 +310,14 @@ def load_documents(
     file_extensions: Set[str] = DEFAULT_FILE_EXTENSIONS,
     ignore_files: Set[str] = None
 ) -> List[Document]:
-    """Load documents from a directory, filtering out ignored paths."""
+    """
+    Load documents from a directory, filtering out ignored paths.
+    Uses os.walk with followlinks=False to avoid following symbolic links.
+    """
     try:
-        # Get all files recursively
+        # Get all files recursively - DO NOT follow symlinks
         all_files = []
-        for root, dirs, files in os.walk(directory):
+        for root, dirs, files in os.walk(directory, followlinks=False):
             # Skip ignored directories
             dirs[:] = [
                 d for d in dirs
@@ -323,6 +326,11 @@ def load_documents(
 
             for file in files:
                 abs_file_path = os.path.join(root, file)
+
+                # Skip symlinks completely to avoid issues
+                if os.path.islink(abs_file_path):
+                    continue
+
                 if is_valid_file(
                     abs_file_path,
                     ignore_dirs,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  code-indexer:
+  code-indexer-mcp:
     build: .
     ports:
       - "8978:8978"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8978:8978"
     volumes:
       - ./chroma_db:/app/chroma_db  # Persist ChromaDB data
-      - ${PROJECTS_ROOT}:/projects   # Mount projects root directory
+      - ${PROJECTS_ROOT}:/projects:ro   # Mount projects root directory as read-only with no symlink resolution
       - ./container_cache:/root/.cache  # Mount a cache folder into the container
     environment:
       - FASTMCP_PORT=8978


### PR DESCRIPTION
I wanted to use your project, but am currently using Claude Code. I wanted to see how easy it would be to make small changes to make this work with Claude Code.

In this PR:

- changes to README.md, so we are no longer calling this a Cursor specific MCP, as it can be used elsewhere too
- switching to mounting projects as read only - just in case
- preventing symlink traversal: it turns out that if you have absolute or even relative symlinks in any of your projects that you use this tool with, it breaks with that project and will not be able to index - there may be a better solution to this though...

Thanks for your work!